### PR TITLE
prebuild an image for linux builds

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,39 @@
+name: image
+on:
+  pull_request:
+    paths: [dockerfiles/Dockerfile.linux]
+  push:
+    branches: [main, test-me-*]
+    paths: [dockerfiles/Dockerfile.linux]
+
+jobs:
+  image:
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    env:
+      TARGET_TAG: ghcr.io/getsentry/prebuilt-pythons-manylinux-${{ matrix.arch }}-ci
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: enable cross build
+      run: docker run --rm --privileged tonistiigi/binfmt --install arm64
+      if: matrix.arch == 'aarch64'
+    - name: build
+      run: |
+        args=()
+        if docker pull -q "$TARGET_TAG"; then
+          args+=(--cache-from "$TARGET_TAG")
+        fi
+        docker build \
+            "${args[@]}" \
+            --build-arg ARCH=${{ matrix.arch }} \
+            -f dockerfiles/Dockerfile.linux \
+            -t "${TARGET_TAG}:${GITHUB_SHA}" .
+        docker tag "${TARGET_TAG}:${GITHUB_SHA}" "${TARGET_TAG}:latest"
+    - name: push
+      run: |
+        docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< '${{ secrets.GITHUB_TOKEN }}'
+        docker push "${TARGET_TAG}:${GITHUB_SHA}"
+        docker push "${TARGET_TAG}:latest"
+      if: github.event_name != 'pull_request'

--- a/dockerfiles/Dockerfile.linux
+++ b/dockerfiles/Dockerfile.linux
@@ -1,0 +1,22 @@
+ARG ARCH
+FROM quay.io/pypa/manylinux_2_24_${ARCH}
+RUN : \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+        -y --no-install-recommends \
+        libbz2-dev \
+        libdb-dev \
+        libexpat1-dev \
+        libffi-dev \
+        libgdbm-dev \
+        liblzma-dev \
+        libncursesw5-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        patchelf \
+        uuid-dev \
+        xz-utils \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+ENV BUILD_BINARY_IN_CONTAINER=1


### PR DESCRIPTION
this does two things
- simplifies build bootstrapping
- would allow us to build the  `linux-arm64` artifact using cirrus (which only has linux arm64 for pods)