### PR TITLE
linux-image: put python3.8 on PATH by default

### DIFF
--- a/dockerfiles/Dockerfile.linux
+++ b/dockerfiles/Dockerfile.linux
@@ -19,4 +19,4 @@ RUN : \
         xz-utils \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
-ENV BUILD_BINARY_IN_CONTAINER=1
+ENV BUILD_BINARY_IN_CONTAINER=1 PATH=/opt/python/cp38-cp38/bin:$PATH


### PR DESCRIPTION
this is needed to run the build on cirrus without defaulting to python 3.5:

```console
$ python3 -m build_binary 3.8.13
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.5/runpy.py", line 153, in _get_module_details
    code = loader.get_code(mod_name)
  File "<frozen importlib._bootstrap_external>", line 775, in get_code
  File "<frozen importlib._bootstrap_external>", line 735, in source_to_code
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/tmp/cirrus-ci-build/build_binary.py", line 25
    major: int
         ^
SyntaxError: invalid syntax
```