### PR TITLE
upload artifacts to gcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,11 +44,16 @@ jobs:
         name: dist-${{ matrix.job }}
         path: dist/*
 
-  collect:
+  collect-and-deploy:
     needs: [build, cirrus]
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
     - uses: actions/download-artifact@v3
       with:
         path: dist
-    - run: ls -al dist
+    - uses: google-github-actions/auth@v0
+      with:
+        credentials_json: ${{ secrets.SENTRY_DEV_INFRA_ASSETS_WRITER }}
+    - uses: google-github-actions/setup-gcloud@v0
+    - run: bin/upload-artifacts

--- a/bin/upload-artifacts
+++ b/bin/upload-artifacts
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import os.path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--dist', default='dist')
+    args = parser.parse_args()
+
+    by_version = collections.defaultdict(list)
+    for root, _, fnames in os.walk(args.dist):
+        for fname in fnames:
+            _, version, _ = fname.split('-')
+            by_version[version].append(os.path.join(root, fname))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for version, names in by_version.items():
+            if len(names) != 4:
+                raise SystemExit(f'expected 4 files for {version}: {names}')
+
+            for name in names:
+                shutil.copy(name, tmpdir)
+
+            checksums = os.path.join(tmpdir, f'python-{version}.sha256sums')
+            with open(checksums, 'w') as checksums_f:
+                for name in sorted(os.path.basename(name) for name in names):
+                    with open(os.path.join(tmpdir, name), 'rb') as tgz:
+                        checksum = hashlib.sha256(tgz.read()).hexdigest()
+                    for f in (sys.stdout, checksums_f):
+                        print(f'{checksum}  {os.path.basename(name)}', file=f)
+
+        cmd = (
+            'gsutil',
+            '-m',  # parallel
+            'cp',
+            '-n',  # no-clobber
+            os.path.join(tmpdir, '*'),  # so the tmpdir name isn't uploaded
+            'gs://sentry-dev-infra-assets/prebuilt-pythons/',
+        )
+        if args.dry_run:
+            print(f'would run `{shlex.join(cmd)}`')
+            return 0
+        else:
+            return subprocess.call(cmd)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
tried this locally (and then deleted the result from the bucket afterwards)

```console
$ ./bin/upload-artifacts 
eb0fa23cb56895ed1c765ab367e543d89780efde12ec153d444436c9a5480020  python-3.8.13-macosx_11_0_x86_64.tgz
c4a9c643b973033643049011ee5847e47ee8461d88693afca8223c6bda99f9fa  python-3.8.13-macosx_12_0_arm64.tgz
4df056685ae38e3abc6232ad8dc5650a20bb84efd9f030765d0d8920501d2436  python-3.8.13-manylinux_2_24_aarch64.tgz
ca90b29b182301ecf13720fac0ccdb70187b1bef25096c3ded284b40b284b387  python-3.8.13-manylinux_2_24_x86_64.tgz
If you experience problems with multiprocessing on MacOS, they might be related to https://bugs.python.org/issue33725. You can disable multiprocessing by editing your .boto config or by adding the following flag to your command: `-o "GSUtil:parallel_process_count=1"`. Note that multithreading is still available even if you disable multiprocessing.

Copying file:///var/folders/1c/5r_6j4rs0j56vnt8kq83tmvh0000gn/T/tmp99g0bslv/python-3.8.13-manylinux_2_24_x86_64.tgz [Content-Type=application/gzip]...
Copying file:///var/folders/1c/5r_6j4rs0j56vnt8kq83tmvh0000gn/T/tmp99g0bslv/python-3.8.13-macosx_11_0_x86_64.tgz [Content-Type=application/gzip]...
Copying file:///var/folders/1c/5r_6j4rs0j56vnt8kq83tmvh0000gn/T/tmp99g0bslv/python-3.8.13-macosx_12_0_arm64.tgz [Content-Type=application/gzip]...
Copying file:///var/folders/1c/5r_6j4rs0j56vnt8kq83tmvh0000gn/T/tmp99g0bslv/python-3.8.13-manylinux_2_24_aarch64.tgz [Content-Type=application/gzip]...
Copying file:///var/folders/1c/5r_6j4rs0j56vnt8kq83tmvh0000gn/T/tmp99g0bslv/python-3.8.13.sha256sums [Content-Type=application/octet-stream]...
\ [5/5 files][206.2 MiB/206.2 MiB] 100% Done   2.2 MiB/s ETA 00:00:00           
Operation completed over 5 objects/206.2 MiB.              

$ gsutil ls gs://sentry-dev-infra-assets/prebuilt-pythons/
gs://sentry-dev-infra-assets/prebuilt-pythons/python-3.8.13-macosx_11_0_x86_64.tgz
gs://sentry-dev-infra-assets/prebuilt-pythons/python-3.8.13-macosx_12_0_arm64.tgz
gs://sentry-dev-infra-assets/prebuilt-pythons/python-3.8.13-manylinux_2_24_aarch64.tgz
gs://sentry-dev-infra-assets/prebuilt-pythons/python-3.8.13-manylinux_2_24_x86_64.tgz
gs://sentry-dev-infra-assets/prebuilt-pythons/python-3.8.13.sha256sums                      
```