### PR TITLE
build based on ubuntu:18.04

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -10,7 +10,7 @@ jobs:
   image:
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
+        arch: [amd64, arm64]
     env:
       TARGET_TAG: ghcr.io/getsentry/prebuilt-pythons-manylinux-${{ matrix.arch }}-ci
     runs-on: ubuntu-latest
@@ -18,16 +18,16 @@ jobs:
     - uses: actions/checkout@v3
     - name: enable cross build
       run: docker run --rm --privileged tonistiigi/binfmt --install arm64
-      if: matrix.arch == 'aarch64'
+      if: matrix.arch == 'arm64'
     - name: build
       run: |
         args=()
         if docker pull -q "$TARGET_TAG"; then
           args+=(--cache-from "$TARGET_TAG")
         fi
-        docker build \
+        docker buildx build \
             "${args[@]}" \
-            --build-arg ARCH=${{ matrix.arch }} \
+            --platform linux/${{ matrix.arch }} \
             --tag "${TARGET_TAG}:${GITHUB_SHA}" \
             docker
         docker tag "${TARGET_TAG}:${GITHUB_SHA}" "${TARGET_TAG}:latest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-ARG ARCH
-FROM quay.io/pypa/manylinux_2_24_${ARCH}
+FROM ubuntu:18.04
 RUN : \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \
@@ -15,9 +14,12 @@ RUN : \
         libsqlite3-dev \
         libssl-dev \
         patchelf \
+        python3.8-distutils \
+        python3.8-venv \
         uuid-dev \
         xz-utils \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 # match minimum target for this script (macos python3 is 3.8)
-ENV BUILD_BINARY_IN_CONTAINER=1 PATH=/opt/python/cp38-cp38/bin:$PATH
+RUN python3.8 -m venv /venv
+ENV BUILD_BINARY_IN_CONTAINER=1 PATH=/venv/bin:$PATH


### PR DESCRIPTION
- this will bump compatibility to `manylinux_2_27`
- production is `manylinux_2_28`
- I chose ubuntu instead of debian because it ships with python3.8 and I don't
  want to rewrite code to target python 3.7
- this is needed to have a new-enough libssl to build python 3.10
- I also changed the docker image names to match the docker architectures