### PR TITLE
ref: upgrade actions/setup-python to avoid set-output deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - run: pip install tox


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos