### PR TITLE
remove gcloud utils install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,5 +58,4 @@ jobs:
     - uses: google-github-actions/auth@v0
       with:
         credentials_json: ${{ secrets.SENTRY_DEV_INFRA_ASSETS_WRITER }}
-    - uses: google-github-actions/setup-gcloud@v0
     - run: bin/upload-artifacts


### PR DESCRIPTION
github includes these by default

Committed via https://github.com/asottile/all-repos