### PR TITLE
fix gcloud auth by explicitly logging in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,5 @@ jobs:
     - uses: google-github-actions/auth@v0
       with:
         credentials_json: ${{ secrets.SENTRY_DEV_INFRA_ASSETS_WRITER }}
+    - run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
     - run: bin/upload-artifacts


### PR DESCRIPTION


apparently gsutil doesn't use GOOGLE_APPLICATION_CREDENTIALS unless explicitly logged in

tried this out on a test branch
